### PR TITLE
feat: exclude latest version from list-all

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -6,4 +6,4 @@ cmd="curl --silent --location"
 releases_path="https://mirror.openshift.com/pub/openshift-v4/clients/crc/"
 
 # kinda hacky, but there isn't something like a Github API REST endpoint to call, so just parse the HTML output
-eval "$cmd $releases_path" | grep -o "<a href=\"$releases_path\([0-9a-z\.\-]\)\+/\">" | grep -o "\([0-9]\+\.\)\+[0-9]\|latest" | sort -V | xargs
+eval "$cmd $releases_path" | grep -o "<a href=\"$releases_path\([0-9a-z\.\-]\)\+/\">" | grep -o "\([0-9]\+\.\)\+[0-9]\" | sort -V | xargs


### PR DESCRIPTION
`latest` is the same as the latest version `2.57.0`, so remove it from `ls-remote` output.

- 2.57.0: [sha256sum.txt](https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/crc/2.57.0/sha256sum.txt)
- latest: [sha256sum.txt](https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/crc/2.57.0/sha256sum.txt)